### PR TITLE
bump patch version in xrp-app-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "stylify": "^0.1.5",
     "stylus": "^0.47.3",
     "uglifyjs": "^2.3.6",
-    "xrp-app-lib": "^1.1.1"
+    "xrp-app-lib": "^1.1.2"
   }
 }


### PR DESCRIPTION
Removes the one call to Ripple REST in favor of a direct call to rippled using ripple-lib 0.17.

Do please test out a build with the new branch if you get a chance : D